### PR TITLE
docs: update previously rpcproviderUrl-related documentation

### DIFF
--- a/packages/docs/docs/deploying/deploy-nextjs-app.mdx
+++ b/packages/docs/docs/deploying/deploy-nextjs-app.mdx
@@ -35,7 +35,6 @@ You can configure different settings for your dapp at `packages/nextjs/scaffold.
 export type ScaffoldConfig = {
   targetNetworks: readonly Chain[];
   pollingInterval: number;
-  rpcProviderUrl: string;
   walletAutoConnect: boolean;
   autoConnectTTL: number;
 
@@ -53,11 +52,6 @@ Array of blockchain networks where your dapp is deployed. Use values from `suppo
 #### - pollingInterval
 
 The interval in milliseconds at which your front-end application polls the RPC servers for fresh data. _Note that this setting does not affect the local network._
-
-#### - rpcProviderUrl
-
-Default RPC url from Scaffold-Stark 2.
-If you are using your own RPC, you can put it within the `NEXT_PUBLIC_PROVIDER_URL` environment variable.
 
 #### - walletAutoConnect
 

--- a/packages/docs/docs/recipes/AddControllerConnector.md
+++ b/packages/docs/docs/recipes/AddControllerConnector.md
@@ -58,6 +58,7 @@ const containsDevnet = (networks: readonly Chain[]) => {
 };
 
 // Function to get rpcProviderUrl, using your environment variables
+// environment variables here need to be uncommented, depending on the network the user wants activated
 const getRpcUrl = (networkName: string): string => {
   const devnetRpcUrl = process.env.NEXT_PUBLIC_DEVNET_PROVIDER_URL;
   const sepoliaRpcUrl = process.env.NEXT_PUBLIC_SEPOLIA_PROVIDER_URL;

--- a/packages/docs/docs/recipes/AddControllerConnector.md
+++ b/packages/docs/docs/recipes/AddControllerConnector.md
@@ -57,15 +57,45 @@ const containsDevnet = (networks: readonly Chain[]) => {
   return networks.some(it => it.network === "devnet");
 };
 
+// Function to get rpcProviderUrl, using your environment variables
+const getRpcUrl = (networkName: string): string => {
+  const devnetRpcUrl = process.env.NEXT_PUBLIC_DEVNET_PROVIDER_URL;
+  const sepoliaRpcUrl = process.env.NEXT_PUBLIC_SEPOLIA_PROVIDER_URL;
+  const mainnetRpcUrl = process.env.NEXT_PUBLIC_MAINNET_PROVIDER_URL;
+  const fallBack = process.env.NEXT_PUBLIC_PROVIDER_URL;
+
+  let rpcUrl = "";
+
+  switch (networkName) {
+    case "devnet":
+      rpcUrl = devnetRpcUrl || fallBack || "";
+      break;
+    case "sepolia":
+      rpcUrl = sepoliaRpcUrl || fallBack || "";
+      break;
+    case "mainnet":
+      rpcUrl = mainnetRpcUrl || fallBack || "";
+      break;
+    default:
+      rpcUrl = "";
+      break;
+  }
+
+  return rpcUrl;
+};
+
+const currentNetwork = scaffoldConfig.targetNetworks[0];
+const currentNetworkName = currentNetwork.network;
+
 // Provider configuration based on Scaffold settings
 export const getProvider = () => {
-  if (scaffoldConfig.rpcProviderUrl === "" || containsDevnet(scaffoldConfig.targetNetworks)) {
+  if (getRpcUrl(currentNetworkName) === "" || containsDevnet(scaffoldConfig.targetNetworks)) {
     return publicProvider();
   }
 
   return jsonRpcProvider({
     rpc: () => ({
-      nodeUrl: scaffoldConfig.rpcProviderUrl,
+      nodeUrl: getRpcUrl(currentNetworkName),
       chainId: starknetChainId(scaffoldConfig.targetNetworks[0].id),
     }),
   });

--- a/packages/docs/docs/recipes/AddControllerConnector.md
+++ b/packages/docs/docs/recipes/AddControllerConnector.md
@@ -63,19 +63,18 @@ const getRpcUrl = (networkName: string): string => {
   const devnetRpcUrl = process.env.NEXT_PUBLIC_DEVNET_PROVIDER_URL;
   const sepoliaRpcUrl = process.env.NEXT_PUBLIC_SEPOLIA_PROVIDER_URL;
   const mainnetRpcUrl = process.env.NEXT_PUBLIC_MAINNET_PROVIDER_URL;
-  const fallBack = process.env.NEXT_PUBLIC_PROVIDER_URL;
 
   let rpcUrl = "";
 
   switch (networkName) {
     case "devnet":
-      rpcUrl = devnetRpcUrl || fallBack || "";
+      rpcUrl = devnetRpcUrl || "";
       break;
     case "sepolia":
-      rpcUrl = sepoliaRpcUrl || fallBack || "";
+      rpcUrl = sepoliaRpcUrl || "";
       break;
     case "mainnet":
-      rpcUrl = mainnetRpcUrl || fallBack || "";
+      rpcUrl = mainnetRpcUrl || "";
       break;
     default:
       rpcUrl = "";

--- a/packages/nextjs/next.config.js
+++ b/packages/nextjs/next.config.js
@@ -9,8 +9,8 @@ const nextConfig = {
   async rewrites() {
     return [
       {
-        source: '/docs/:path*',
-        destination: 'http://localhost:3001/:path*',
+        source: "/docs/:path*",
+        destination: "http://localhost:3001/:path*",
       },
     ];
   },


### PR DESCRIPTION
## Changes Made

- [ ] Bug
- [ ] Enhancement
- [x] Documentation

I updated some documentation that previously made mention of the usage of the rpcProviderUrl from the ScaffoldConfig

I removed the rpcProviderUrl from the definitions of the scaffoldConfig where necessary, and in examples that needed the rpc, I replaced with the getRpcUrl as described in the provider.ts
